### PR TITLE
Updates for 2.0-RC4/Integration changes

### DIFF
--- a/SpringSecuritySamlGrailsPlugin.groovy
+++ b/SpringSecuritySamlGrailsPlugin.groovy
@@ -268,6 +268,8 @@ SAML 2.x support for the Spring Security Plugin
 		
 		webSSOprofileConsumer(WebSSOProfileConsumerImpl){
 			responseSkew = conf.saml.responseSkew
+			maxAuthenticationAge = conf.saml.maxAuthenticationAge
+			maxAssertionTime = conf.saml.maxAssertionTime
 		}
 		
 		webSSOprofile(WebSSOProfileImpl)

--- a/application.properties
+++ b/application.properties
@@ -1,5 +1,5 @@
 #Grails Metadata file
-#Tue Sep 30 10:43:08 CDT 2014
-app.grails.version=2.4.3
+#Mon Feb 16 20:38:37 EST 2015
+app.grails.version=2.4.4
 app.name=spring-security-saml
 app.servlet.version=2.5

--- a/grails-app/conf/DefaultSamlSecurityConfig.groovy
+++ b/grails-app/conf/DefaultSamlSecurityConfig.groovy
@@ -6,6 +6,8 @@ security {
 		afterLogoutUrl = '/'
 		userGroupAttribute = "memberOf"
 		responseSkew = 60
+		maxAssertionTime = 3000
+		maxAuthenticationAge = 7200
 		autoCreate {
 			active =  false
 			key = 'username'

--- a/grails-app/controllers/es/salenda/grails/plugins/springsecurity/saml/MetadataController.groovy
+++ b/grails-app/controllers/es/salenda/grails/plugins/springsecurity/saml/MetadataController.groovy
@@ -66,14 +66,14 @@ class MetadataController {
 	def save = {
 
 		metadataGenerator.setEntityId(params.entityId)
-		metadataGenerator.setEntityAlias(params.alias)
+		//metadataGenerator.setEntityAlias(params.alias)
 		metadataGenerator.setEntityBaseURL(params.baseURL)
-		metadataGenerator.setSignMetadata(params.signMetadata as boolean)
+		//metadataGenerator.setSignMetadata(params.signMetadata as boolean)
 		metadataGenerator.setRequestSigned(params.requestSigned as boolean)
 		metadataGenerator.setWantAssertionSigned(params.wantAssertionSigned as boolean)
-		metadataGenerator.setSigningKey(params.signingKey)
-		metadataGenerator.setEncryptionKey(params.encryptionKey)
-		metadataGenerator.setTlsKey(params.tlsKey)
+		//metadataGenerator.setSigningKey(params.signingKey)
+		//metadataGenerator.setEncryptionKey(params.encryptionKey)
+		//metadataGenerator.setTlsKey(params.tlsKey)
 
 
 		//<editor-fold desc="SSO Bindings">
@@ -115,7 +115,7 @@ class MetadataController {
 		metadataGenerator.setBindingsHoKSSO(bindingsHoKSSO)
 		//</editor-fold>
 
-		metadataGenerator.setIncludeDiscovery(params.includeDiscovery as boolean)
+		metadataGenerator.setIncludeDiscoveryExtension(params.includeDiscovery as boolean)
 
 		def descriptor = metadataGenerator.generateMetadata()
 

--- a/src/groovy/es/salenda/grails/plugins/springsecurity/saml/SpringSamlUserDetailsService.groovy
+++ b/src/groovy/es/salenda/grails/plugins/springsecurity/saml/SpringSamlUserDetailsService.groovy
@@ -88,7 +88,7 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
 
 		if (samlUserAttributeMappings?.username) {
 
-			def attribute = credential.getAttributeByName(samlUserAttributeMappings.username)
+			def attribute = credential.getAttribute(samlUserAttributeMappings.username)
 			def value = attribute?.attributeValues?.value
 			return value?.first()
 		} else {
@@ -99,11 +99,18 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
 
 	protected Object mapAdditionalAttributes(credential, user) {
 		samlUserAttributeMappings.each { key, value ->
-			def attribute = credential.getAttributeByName(value)
-			def samlValue = attribute?.attributeValues?.value
-			if (samlValue) {
-				user."$key" = samlValue?.first()
-			}
+			if (user."$key" instanceof String) {
+				def attrValue = credential.getAttributeAsString(value)
+				user."$key" = attrValue
+			} else {
+				def attributes = credential.getAttributeAsStringArray(value)
+				attributes?.each() { attrValue ->
+					if (! user."$key") {
+						user."$key" = []
+					}
+					user."$key" << attrValue
+				}
+                        }
 		}
 		user
 	}
@@ -120,6 +127,9 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
 			if (authority) {
 				authorities.add(new GrantedAuthorityImpl(authority."$authorityNameField"))
 			}
+		}
+		if ( authorities.size() == 0 ) {
+			authorities.add(GormUserDetailsService.NO_ROLE)
 		}
 
 		return authorities
@@ -139,22 +149,20 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
 		def userGroups = []
 
 		if (samlUserGroupAttribute) {
-			def attributes = credential.getAttributeByName(samlUserGroupAttribute)
-
-			attributes.each { attribute ->
-				attribute.attributeValues?.each { attributeValue ->
-					log.debug "Processing group attribute value: ${attributeValue}"
-
-					def groupString = attributeValue.value
+			def attributeValues = credential.getAttributeAsStringArray(samlUserGroupAttribute)
+			attributeValues.each { groupString ->
+				def groupStringValue = groupString
+				if ( groupString.startsWith("CN") ) {
 					groupString?.tokenize(',').each { token ->
 						def keyValuePair = token.tokenize('=')
-
 						if (keyValuePair.first() == 'CN') {
-							userGroups << keyValuePair.last()
+							groupStringValue = keyValuePair.last()
 						}
 					}
 				}
+				userGroups << groupStringValue
 			}
+				
 		}
 
 		userGroups
@@ -186,7 +194,13 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
 			userClazz.withTransaction {
 				def existingUser = userClazz.findWhere(whereClause)
 				if (!existingUser) {
-					if (!user.save()) throw new UsernameNotFoundException("Could not save user ${user}");
+					if (!user.save()) {
+						def save_errors=""
+						user.errors.each {
+							save_errors+=it
+						}
+						throw new UsernameNotFoundException("Could not save user ${user} - ${save_errors}");
+					}               
 				} else {
 					user = updateUserProperties(existingUser, user)
 


### PR DESCRIPTION
Hi Jeff,
    Please find the following changes I made during implementation:
### Updates for 2.0-RC4

Mainly metadata generation referenced a bunch of methods that no longer exist.
### getSamlGroups() now supports groupnames without CN=groupname format

This was so that I could supply my roles as clear text names from my ADFS server(as opposed to LDAP memberships)
### Updated authorities to add NO_ROLE if no authorities are granted. GormUserDetailsService does this by default

Just seemed nice to keep that feature.  Just sorta happened on the default as I was getting this plugin to work.
### mapAdditionalAttributes updated to support Assertions that are lists

I assert from ADFS server a list of sub-accounts that the user has access to.  The old AdditionalAttributes method could only handle Strings.
### promoted maxAssertionTime and maxAuthenticationAge as configuration options

This was so that ADFS could have its default 8 hour security challenge.  Our default was 2 hours resulting in failed authentications.
### more debug for a save operation

I needed this debug to troubleshoot an issue, figured other people might find it useful

Thanks,

Anthony
