### PR TITLE
Fixed unit tests and MetadataGenerator

### DIFF
--- a/SpringSecuritySamlGrailsPlugin.groovy
+++ b/SpringSecuritySamlGrailsPlugin.groovy
@@ -268,6 +268,8 @@ SAML 2.x support for the Spring Security Plugin
 		
 		webSSOprofileConsumer(WebSSOProfileConsumerImpl){
 			responseSkew = conf.saml.responseSkew
+			maxAuthenticationAge = conf.saml.maxAuthenticationAge
+			maxAssertionTime = conf.saml.maxAssertionTime
 		}
 		
 		webSSOprofile(WebSSOProfileImpl)

--- a/application.properties
+++ b/application.properties
@@ -1,5 +1,5 @@
 #Grails Metadata file
-#Tue Sep 30 10:43:08 CDT 2014
-app.grails.version=2.4.3
+#Mon Feb 16 20:38:37 EST 2015
+app.grails.version=2.4.5
 app.name=spring-security-saml
 app.servlet.version=2.5

--- a/grails-app/conf/DefaultSamlSecurityConfig.groovy
+++ b/grails-app/conf/DefaultSamlSecurityConfig.groovy
@@ -6,6 +6,8 @@ security {
 		afterLogoutUrl = '/'
 		userGroupAttribute = "memberOf"
 		responseSkew = 60
+		maxAssertionTime = 3000
+		maxAuthenticationAge = 7200
 		autoCreate {
 			active =  false
 			key = 'username'

--- a/grails-app/controllers/es/salenda/grails/plugins/springsecurity/saml/MetadataController.groovy
+++ b/grails-app/controllers/es/salenda/grails/plugins/springsecurity/saml/MetadataController.groovy
@@ -66,14 +66,14 @@ class MetadataController {
 	def save = {
 
 		metadataGenerator.setEntityId(params.entityId)
-		metadataGenerator.setEntityAlias(params.alias)
+		//metadataGenerator.setEntityAlias(params.alias)
 		metadataGenerator.setEntityBaseURL(params.baseURL)
-		metadataGenerator.setSignMetadata(params.signMetadata as boolean)
+		//metadataGenerator.setSignMetadata(params.signMetadata as boolean)
 		metadataGenerator.setRequestSigned(params.requestSigned as boolean)
 		metadataGenerator.setWantAssertionSigned(params.wantAssertionSigned as boolean)
-		metadataGenerator.setSigningKey(params.signingKey)
-		metadataGenerator.setEncryptionKey(params.encryptionKey)
-		metadataGenerator.setTlsKey(params.tlsKey)
+		//metadataGenerator.setSigningKey(params.signingKey)
+		//metadataGenerator.setEncryptionKey(params.encryptionKey)
+		//metadataGenerator.setTlsKey(params.tlsKey)
 
 
 		//<editor-fold desc="SSO Bindings">
@@ -115,7 +115,7 @@ class MetadataController {
 		metadataGenerator.setBindingsHoKSSO(bindingsHoKSSO)
 		//</editor-fold>
 
-		metadataGenerator.setIncludeDiscovery(params.includeDiscovery as boolean)
+		metadataGenerator.setIncludeDiscoveryExtension(params.includeDiscovery as boolean)
 
 		def descriptor = metadataGenerator.generateMetadata()
 
@@ -124,6 +124,14 @@ class MetadataController {
 		extendedMetadata.setRequireLogoutRequestSigned(params.requireLogoutRequestSigned as boolean)
 		extendedMetadata.setRequireLogoutResponseSigned(params.requireLogoutResponseSigned as boolean)
 		extendedMetadata.setRequireArtifactResolveSigned(params.requireArtifactResolveSigned as boolean)
+
+		// fields moved from MetadataGenerator to ExtendedMetadata since Spring SAML 1.0 RC2
+		extendedMetadata.setAlias(params.alias)
+		extendedMetadata.setSignMetadata(params.signMetadata as boolean)
+		extendedMetadata.setSigningKey(params.signingKey)
+		extendedMetadata.setEncryptionKey(params.encryptionKey)
+		extendedMetadata.setTlsKey(params.tlsKey)
+		extendedMetadata.setIdpDiscoveryEnabled(metadataGenerator.isIncludeDiscoveryExtension())
 
 		if (params.store) {
 			MetadataMemoryProvider memoryProvider = new MetadataMemoryProvider(descriptor)

--- a/src/groovy/es/salenda/grails/plugins/springsecurity/saml/SpringSamlUserDetailsService.groovy
+++ b/src/groovy/es/salenda/grails/plugins/springsecurity/saml/SpringSamlUserDetailsService.groovy
@@ -121,6 +121,9 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
 				authorities.add(new GrantedAuthorityImpl(authority."$authorityNameField"))
 			}
 		}
+		if ( authorities.size() == 0 ) {
+			authorities.add(GormUserDetailsService.NO_ROLE)
+		}
 
 		return authorities
 	}

--- a/src/groovy/es/salenda/grails/plugins/springsecurity/saml/SpringSamlUserDetailsService.groovy
+++ b/src/groovy/es/salenda/grails/plugins/springsecurity/saml/SpringSamlUserDetailsService.groovy
@@ -88,7 +88,7 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
 
 		if (samlUserAttributeMappings?.username) {
 
-			def attribute = credential.getAttributeByName(samlUserAttributeMappings.username)
+			def attribute = credential.getAttribute(samlUserAttributeMappings.username)
 			def value = attribute?.attributeValues?.value
 			return value?.first()
 		} else {
@@ -99,7 +99,7 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
 
 	protected Object mapAdditionalAttributes(credential, user) {
 		samlUserAttributeMappings.each { key, value ->
-			def attribute = credential.getAttributeByName(value)
+			def attribute = credential.getAttribute(value)
 			def samlValue = attribute?.attributeValues?.value
 			if (samlValue) {
 				user."$key" = samlValue?.first()
@@ -139,7 +139,7 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
 		def userGroups = []
 
 		if (samlUserGroupAttribute) {
-			def attributes = credential.getAttributeByName(samlUserGroupAttribute)
+			def attributes = credential.getAttribute(samlUserGroupAttribute)
 
 			attributes.each { attribute ->
 				attribute.attributeValues?.each { attributeValue ->

--- a/src/groovy/es/salenda/grails/plugins/springsecurity/saml/SpringSamlUserDetailsService.groovy
+++ b/src/groovy/es/salenda/grails/plugins/springsecurity/saml/SpringSamlUserDetailsService.groovy
@@ -189,7 +189,13 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
 			userClazz.withTransaction {
 				def existingUser = userClazz.findWhere(whereClause)
 				if (!existingUser) {
-					if (!user.save()) throw new UsernameNotFoundException("Could not save user ${user}");
+					if (!user.save()) {
+						def save_errors=""
+						user.errors.each {
+							save_errors+=it
+						}
+						throw new UsernameNotFoundException("Could not save user ${user} - ${save_errors}");
+					}
 				} else {
 					user = updateUserProperties(existingUser, user)
 

--- a/src/groovy/es/salenda/grails/plugins/springsecurity/saml/SpringSamlUserDetailsService.groovy
+++ b/src/groovy/es/salenda/grails/plugins/springsecurity/saml/SpringSamlUserDetailsService.groovy
@@ -88,9 +88,7 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
 
 		if (samlUserAttributeMappings?.username) {
 
-			def attribute = credential.getAttribute(samlUserAttributeMappings.username)
-			def value = attribute?.attributeValues?.value
-			return value?.first()
+			return credential.getAttributeAsString(samlUserAttributeMappings.username)
 		} else {
 			// if no mapping provided for username attribute then assume it is the returned subject in the assertion
 			return credential.nameID?.value
@@ -99,10 +97,20 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
 
 	protected Object mapAdditionalAttributes(credential, user) {
 		samlUserAttributeMappings.each { key, value ->
-			def attribute = credential.getAttribute(value)
-			def samlValue = attribute?.attributeValues?.value
-			if (samlValue) {
-				user."$key" = samlValue?.first()
+			// Note that check "user."$key" instanceof String" will fail when field value is null.
+			//  Instead, we have to check field type
+			Class keyType = grailsApplication.getDomainClass(userDomainClassName).properties.find { prop -> prop.name == "$key" }.type
+			if (keyType != null && (keyType.isArray() || Collection.class.isAssignableFrom(keyType))) {
+				def attributes = credential.getAttributeAsStringArray(value)
+				attributes?.each() { attrValue ->
+					if (! user."$key") {
+						user."$key" = []
+					}
+					user."$key" << attrValue
+				}
+			} else {
+				def attrValue = credential.getAttributeAsString(value)
+				user."$key" = attrValue
 			}
 		}
 		user
@@ -142,22 +150,20 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
 		def userGroups = []
 
 		if (samlUserGroupAttribute) {
-			def attributes = credential.getAttribute(samlUserGroupAttribute)
-
-			attributes.each { attribute ->
-				attribute.attributeValues?.each { attributeValue ->
-					log.debug "Processing group attribute value: ${attributeValue}"
-
-					def groupString = attributeValue.value
+			def attributeValues = credential.getAttributeAsStringArray(samlUserGroupAttribute)
+			attributeValues.each { groupString ->
+				def groupStringValue = groupString
+				if ( groupString.startsWith("CN") ) {
 					groupString?.tokenize(',').each { token ->
 						def keyValuePair = token.tokenize('=')
-
 						if (keyValuePair.first() == 'CN') {
-							userGroups << keyValuePair.last()
+							groupStringValue = keyValuePair.last()
 						}
 					}
 				}
+				userGroups << groupStringValue
 			}
+
 		}
 
 		userGroups

--- a/test/integration/es/salenda/grails/plugins/springsecurity/saml/MetadataControllerIntegrationSpec.groovy
+++ b/test/integration/es/salenda/grails/plugins/springsecurity/saml/MetadataControllerIntegrationSpec.groovy
@@ -1,0 +1,19 @@
+package es.salenda.grails.plugins.springsecurity.saml
+
+import grails.test.mixin.*
+import spock.lang.Specification
+
+class MetadataControllerIntegrationSpec extends Specification {
+
+    void testSave() {
+        given:
+        MetadataController controller = new MetadataController()
+        when:
+        controller.params << [entityId: 'entityIdTest', alias: 'entityAlias', baseURL: 'https://localhost:54321/testsp',
+        ]
+        controller.save()
+
+        then:
+        controller.response.redirectedUrl == '/metadata/show?entityId='+'entityIdTest'
+    }
+}

--- a/test/unit/es/salenda/grails/plugins/springsecurity/saml/SpringSamlUserDetailsServiceSpec.groovy
+++ b/test/unit/es/salenda/grails/plugins/springsecurity/saml/SpringSamlUserDetailsServiceSpec.groovy
@@ -1,25 +1,28 @@
+
 package es.salenda.grails.plugins.springsecurity.saml
 
+import grails.plugin.springsecurity.userdetails.GormUserDetailsService;
 import grails.plugin.springsecurity.userdetails.GrailsUser
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
+
 import org.codehaus.groovy.grails.commons.DefaultGrailsApplication
 import org.opensaml.saml2.core.impl.AssertionImpl
 import org.opensaml.saml2.core.impl.NameIDImpl
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.saml.SAMLCredential
+
 import spock.lang.Specification
 import spock.util.mop.ConfineMetaClassChanges
 import test.TestRole
 import test.TestSamlUser
 import test.TestUserRole
-
 import static es.salenda.grails.plugins.springsecurity.saml.UnitTestUtils.*
 
 @TestFor(SpringSamlUserDetailsService)
 @Mock([TestSamlUser, TestRole, TestUserRole])
 class SpringSamlUserDetailsServiceSpec extends Specification {
-    def credential, nameID, assertion, mockGrailsAplication, testRole, testRole2
+    def credential, nameID, assertion, mockGrailsAplication, testRole, testRole2, testNoRole
     def service
 
     String username = "jackSparrow"
@@ -54,6 +57,10 @@ class SpringSamlUserDetailsServiceSpec extends Specification {
 
         testRole = new TestRole(authority: ROLE)
         testRole2 = new TestRole(authority: "FAKEROLE2")
+
+        // Persistent NO_ROLE is needed if no authorities are granted
+        testNoRole = new TestRole(authority: GormUserDetailsService.NO_ROLE)
+        testNoRole.save()
 
         // set default username to be returned in the saml response
         setMockSamlAttributes(credential, ["$USERNAME_ATTR_NAME": username])

--- a/test/unit/es/salenda/grails/plugins/springsecurity/saml/UnitTestUtils.groovy
+++ b/test/unit/es/salenda/grails/plugins/springsecurity/saml/UnitTestUtils.groovy
@@ -63,38 +63,36 @@ class UnitTestUtils {
 		   return null
 	   }
    }
-   
-   
-   static void setMockSamlAttributes(credential, attributes=[:]) {
-	   credential.metaClass.getAttribute = { String name ->
-		   if ( name == USERNAME_ATTR_NAME) {
-			   return [attributeValues: [
-					   [value: attributes.get("${USERNAME_ATTR_NAME}")]
-				   ]
-			   ]
-		   }
-		   else if (name == MAIL_ATTR_NAME) {
-			   return [attributeValues: [
-					   [value: attributes.get("${MAIL_ATTR_NAME}")]
-				   ]
-			   ]
-		   }
-		   else if (name == FIRSTNAME_ATTR_NAME) {
-				return [attributeValues: [
-						   [value: attributes.get("${FIRSTNAME_ATTR_NAME}")]
-					   ]
-				   ]
-			}
-		   else if (name == GROUP_ATTR_NAME) {
-			   return [
-				   [attributeValues: [
-						   [value: attributes.get("${GROUP_ATTR_NAME}")]
-					   ]
-				   ]
-			   ]
-		   }
 
-		   return []
+   private static def getAttr(def attributes, String name) {
+	   if ( name == USERNAME_ATTR_NAME) {
+		   return attributes.get("${USERNAME_ATTR_NAME}")
+	   }
+	   else if (name == MAIL_ATTR_NAME) {
+		   return attributes.get("${MAIL_ATTR_NAME}")
+	   }
+	   else if (name == FIRSTNAME_ATTR_NAME) {
+			return attributes.get("${FIRSTNAME_ATTR_NAME}")
+		}
+	   else if (name == GROUP_ATTR_NAME) {
+		   return attributes.get("${GROUP_ATTR_NAME}")
+	   }
+
+	   return null
+   }
+
+   static void setMockSamlAttributes(credential, attributes=[:]) {
+	   // getAttributeAsString() and getAttributeAsStringArray() have to be mocked
+	   //   directly, even if they use getAttribute() under the hood
+	   credential.metaClass.getAttributeAsString = { String name ->
+		   getAttr(attributes, name)
+	   }
+	   credential.metaClass.getAttributeAsStringArray = { String name ->
+			def val = getAttr(attributes, name)
+
+			if (val == null)
+				return null
+			val.tokenize(',') // here we assume attributes are stored as comma-separated strings!
 	   }
    }
 }

--- a/test/unit/es/salenda/grails/plugins/springsecurity/saml/UnitTestUtils.groovy
+++ b/test/unit/es/salenda/grails/plugins/springsecurity/saml/UnitTestUtils.groovy
@@ -66,7 +66,7 @@ class UnitTestUtils {
    
    
    static void setMockSamlAttributes(credential, attributes=[:]) {
-	   credential.metaClass.getAttributeByName = { String name ->
+	   credential.metaClass.getAttribute = { String name ->
 		   if ( name == USERNAME_ATTR_NAME) {
 			   return [attributeValues: [
 					   [value: attributes.get("${USERNAME_ATTR_NAME}")]


### PR DESCRIPTION
Hi Jeff,

I fixed incompatibilities with Spring saml 1.0.0.RELEASE. Note this commit should be applied before pull #6 

Details:
- Fields moved from MetadataGenerator to ExtendedMetadata since Spring SAML 1.0 RC2
- SAMLCredential.getAttributeByName renamed to getAttribute
- Added MetadataController test, fixed unit tests

Thanks
Peter
